### PR TITLE
two small edits for clarity

### DIFF
--- a/lib/Parallel/ForkManager.pm
+++ b/lib/Parallel/ForkManager.pm
@@ -114,7 +114,7 @@ sub wait_one_child {
 
   my $kid;
   while (1) {
-    $kid = $s->_waitpid(-1,$flag||=0);
+    $kid = $s->_waitpid($flag||=0);
 
     last unless defined $kid;
 
@@ -237,7 +237,7 @@ sub waitpid_blocking_sleep {
 }
 
 sub _waitpid { # Call waitpid() in the standard Unix fashion.
-    my( $self, undef, $flag ) = @_;
+    my( $self, $flag ) = @_;
 
     return $flag ? $self->_waitpid_non_blocking : $self->_waitpid_blocking;
 }

--- a/lib/Parallel/ForkManager.pm
+++ b/lib/Parallel/ForkManager.pm
@@ -110,11 +110,11 @@ sub wait_children {
 *reap_finished_children=*wait_children; # behavioral synonym for clarity
 
 sub wait_one_child {
-  my ($s,$par)=@_;
+  my ($s,$flag)=@_;
 
   my $kid;
   while (1) {
-    $kid = $s->_waitpid(-1,$par||=0);
+    $kid = $s->_waitpid(-1,$flag||=0);
 
     last unless defined $kid;
 

--- a/lib/Parallel/ForkManager.pm
+++ b/lib/Parallel/ForkManager.pm
@@ -171,7 +171,7 @@ sub wait_for_available_procs {
     my( $self, $nbr ) = @_;
     $nbr ||= 1;
 
-    croak "nbr processes '$nbr' higher than the max nbr of processes (@{[ $self->max_procs ]})"
+    croak "number of processes '$nbr' higher than the max number of processes (@{[ $self->max_procs ]})"
         if $nbr > $self->max_procs;
 
     $self->wait_one_child until $self->max_procs - $self->running_procs >= $nbr;


### PR DESCRIPTION
Two edits:

1. rename a variable so its purpose is significantly clearer (to me, anyway)
2. edit an error message to use the word "number" instead of the abbreviation "nbr" (twice)